### PR TITLE
Add settarget command, fix two swapped protocol elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ the 'help' command. Other commands include:
 * 'input': Read input
 * 'target': Read target
 * 'eflags': Read error flags
+* 'settarget': Set target, takes argument between 0 and 4095, inclusive
 
 ## Copyright and thanks
 

--- a/poller.cpp
+++ b/poller.cpp
@@ -54,7 +54,7 @@ Poller::~Poller() {
 
 void Poller::StopPolling() {
   cancelled.store(true);
-  // FIXME interrupt poller
+  // FIXME interrupt poller, and we can stop ticking in poll()
 }
 
 void Poller::WriteJRKCommand(int cmd, int fd) {
@@ -160,7 +160,8 @@ void Poller::Poll() {
   };
   const auto nfds = sizeof(pfds) / sizeof(*pfds);
   while(!cancelled.load()){
-    auto pret = poll(pfds, nfds, -1);
+    // FIXME should not need to tick, but need signal from StopPolling()
+    auto pret = poll(pfds, nfds, 100);
     if(pret < 0){
       std::cerr << "error polling " << nfds << " fds: " << strerror(errno) << std::endl;
       continue;

--- a/poller.cpp
+++ b/poller.cpp
@@ -16,8 +16,8 @@
 namespace PololuJrkUSB {
 
 constexpr unsigned char JRKCMD_READ_INPUT = 0xa1;
-constexpr unsigned char JRKCMD_READ_FEEDBACK = 0xa3;
-constexpr unsigned char JRKCMD_READ_TARGET = 0xa5;
+constexpr unsigned char JRKCMD_READ_TARGET = 0xa3;
+constexpr unsigned char JRKCMD_READ_FEEDBACK = 0xa5;
 constexpr unsigned char JRKCMD_READ_ERRORS = 0xb5;
 
 int Poller::OpenDev(const char* dev) {
@@ -94,6 +94,22 @@ void Poller::ReadJRKErrors() {
   SendJRKReadCommand(cmd);
 }
 
+void Poller::SetJRKTarget(int target) {
+  if(target < 0 || target > 4095){
+    std::cerr << "invalid target " << target << std::endl;
+    return; // FIXME throw exception?
+  }
+  unsigned char cmdbuf[] = {
+    (unsigned char)(0xC0 + (target & 0x1F)),
+    (unsigned char)((target >> 5) & 0x7F),
+  };
+  auto ss = ::write(devfd, cmdbuf, sizeof(cmdbuf));
+  if(ss < 0 || (size_t)ss < sizeof(cmdbuf)){
+    std::cerr << "error writing to " << devfd << ": " << strerror(errno) << std::endl;
+    return; // FIXME throw exception? hrmmmm
+  }
+}
+
 std::ostream& Poller::HexOutput(std::ostream& s, const unsigned char* data, size_t len) {
   std::ios state(NULL);
   state.copyfmt(s);
@@ -113,8 +129,8 @@ void Poller::HandleUSB() {
   // FIXME save readline state
   while((read(devfd, valbuf, bufsize)) == bufsize){
     int sword = valbuf[1] * 256 + valbuf[0];
-    /*std::cout << "received bytes: 0x";
-    HexOutput(std::cout, valbuf, sizeof(valbuf)) << " (" << sword << ")" << std::endl;*/
+    std::cout << "received bytes: 0x";
+    HexOutput(std::cout, valbuf, sizeof(valbuf)) << " (" << sword << ")" << std::endl;
     if(sent_cmds.empty()){
       std::cerr << "warning: no outstanding command for recv" << std::endl;
       continue;

--- a/poller.h
+++ b/poller.h
@@ -17,6 +17,7 @@ public:
   void ReadJRKFeedback();
   void ReadJRKTarget();
   void ReadJRKErrors();
+  void SetJRKTarget(int target);
   void StopPolling();
 
 private:

--- a/pololu.cpp
+++ b/pololu.cpp
@@ -28,35 +28,50 @@ public:
 void ReadJRKInput(PololuJrkUSB::Poller& poller,
                     std::vector<std::string>::iterator begin,
                     std::vector<std::string>::iterator end) {
-  (void)begin; (void)end; // FIXME
+  if(begin != end){
+    std::cerr << "command does not accept options" << std::endl;
+    return;
+  }
   poller.ReadJRKInput();
 }
 
 void ReadJRKFeedback(PololuJrkUSB::Poller& poller,
                       std::vector<std::string>::iterator begin,
                       std::vector<std::string>::iterator end) {
-  (void)begin; (void)end; // FIXME
+  if(begin != end){
+    std::cerr << "command does not accept options" << std::endl;
+    return;
+  }
   poller.ReadJRKFeedback();
 }
 
 void ReadJRKTarget(PololuJrkUSB::Poller& poller,
                     std::vector<std::string>::iterator begin,
                     std::vector<std::string>::iterator end) {
-  (void)begin; (void)end; // FIXME
+  if(begin != end){
+    std::cerr << "command does not accept options" << std::endl;
+    return;
+  }
   poller.ReadJRKTarget();
 }
 
 void ReadJRKErrors(PololuJrkUSB::Poller& poller,
                     std::vector<std::string>::iterator begin,
                     std::vector<std::string>::iterator end) {
-  (void)begin; (void)end; // FIXME
+  if(begin != end){
+    std::cerr << "command does not accept options" << std::endl;
+    return;
+  }
   poller.ReadJRKErrors();
 }
 
 void StopPolling(PololuJrkUSB::Poller& poller,
                     std::vector<std::string>::iterator begin,
                     std::vector<std::string>::iterator end) {
-  (void)begin; (void)end; // FIXME
+  if(begin != end){
+    std::cerr << "command does not accept options" << std::endl;
+    return;
+  }
   poller.StopPolling();
 }
 

--- a/pololu.cpp
+++ b/pololu.cpp
@@ -57,6 +57,17 @@ void ReadJRKTarget(PololuJrkUSB::Poller& poller,
   poller.ReadJRKTarget();
 }
 
+void SetJRKTarget(PololuJrkUSB::Poller& poller,
+                    std::vector<std::string>::iterator begin,
+                    std::vector<std::string>::iterator end) {
+  if(begin == end || begin + 1 != end){
+    std::cerr << "command requires a single argument [0..4095]" << std::endl;
+    return;
+  }
+  auto target = std::stoi(*begin);
+  poller.SetJRKTarget(target);
+}
+
 void ReadJRKErrors(PololuJrkUSB::Poller& poller,
                     std::vector<std::string>::iterator begin,
                     std::vector<std::string>::iterator end) {
@@ -140,6 +151,7 @@ ReadlineLoop(PololuJrkUSB::Poller& poller) {
     { .cmd = "target", .fxn = &ReadJRKTarget, .help = "send a read target request", },
     { .cmd = "input", .fxn = &ReadJRKInput, .help = "send a read input command", },
     { .cmd = "eflags", .fxn = &ReadJRKErrors, .help = "send a read error flags command", },
+    { .cmd = "settarget", .fxn = &SetJRKTarget, .help = "send set target command (arg: [0..4095])", },
     { .cmd = "", .fxn = nullptr, .help = "", },
   }, *c;
   char* line;
@@ -149,6 +161,7 @@ ReadlineLoop(PololuJrkUSB::Poller& poller) {
       "pololu" RL_START "\033[0;35m" RL_END
       "] " RL_START ANSI_WHITE RL_END);
     if(line == nullptr){
+      poller.StopPolling();
       break;
     }
     std::vector<std::string> tokes;


### PR DESCRIPTION
* Call Poller::StopPolling() in all paths out of ReadlineLoop(), so we don't lock up on exit
* Swap READ_TARGET and READ_FEEDBACK constants, which were inverted
* Add 'settarget' command, the first to take arguments, to ReadlineLoop()
* Reject extra arguments to all readline commands