### PR TITLE
Replace tick+atomic with eventfd, no more ticking

### DIFF
--- a/poller.cpp
+++ b/poller.cpp
@@ -110,7 +110,7 @@ enum class JrkConfigParam {
 int Poller::OpenDev(const char* dev) {
   auto fd = open(dev, O_RDWR | O_CLOEXEC | O_NONBLOCK | O_NOCTTY);
   if(fd < 0){
-    throw std::runtime_error(std::string("couldn't open ") + dev + ": " + strerror(errno));
+    throw std::runtime_error("couldn't open "s + dev + ": " + strerror(errno));
   }
   struct termios term;
   if(tcgetattr(fd, &term)){
@@ -132,7 +132,7 @@ cancelfd(-1) {
   cancelfd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
   if(cancelfd == -1){
     close(devfd);
-    throw std::runtime_error(std::string("couldn't open eventfd: ") + strerror(errno));
+    throw std::runtime_error("couldn't open eventfd: "s + strerror(errno));
   }
   std::cout << "Opened Pololu jrk " << dev << " at fd " << devfd << std::endl;
 }

--- a/poller.cpp
+++ b/poller.cpp
@@ -266,21 +266,20 @@ void Poller::HandleUSB() {
       case JRKCMD_READ_DUTY: std::cout << "Duty cycle is " << USBToSigned16(uword) << std::endl; break;
       case JRKCMD_READ_ERRORS:
         std::cout << "Error bits: " <<
-          ((uword & 0x0001) ? "AwaitingCmd" : "") <<
-          ((uword & 0x0002) ? "NoPower" : "") <<
-          ((uword & 0x0004) ? "DriveError" : "") <<
-          ((uword & 0x0008) ? "InvalidInput" : "") <<
-          ((uword & 0x0010) ? "InputDisconn" : "") <<
-          ((uword & 0x0020) ? "FdbckDisconn" : "") <<
-          ((uword & 0x0040) ? "AmpsExceeded" : "") <<
-          ((uword & 0x0080) ? "SerialSig" : "") <<
-          ((uword & 0x0100) ? "UARTOflow" : "") <<
-          ((uword & 0x0200) ? "SerialOflow" : "") <<
-          ((uword & 0x0400) ? "SerialCRC" : "") <<
-          ((uword & 0x0800) ? "SerialProto" : "") <<
-          ((uword & 0x1000) ? "TimeoutRX" : "") <<
-          ((uword == 0) ? "None" : "") <<
-          std::endl;
+          ((uword & 0x0001) ? "AwaitingCmd " : "") <<
+          ((uword & 0x0002) ? "NoPower " : "") <<
+          ((uword & 0x0004) ? "DriveError " : "") <<
+          ((uword & 0x0008) ? "InvalidInput " : "") <<
+          ((uword & 0x0010) ? "InputDisconn " : "") <<
+          ((uword & 0x0020) ? "FdbckDisconn " : "") <<
+          ((uword & 0x0040) ? "AmpsExceeded " : "") <<
+          ((uword & 0x0080) ? "SerialSig " : "") <<
+          ((uword & 0x0100) ? "UARTOflow " : "") <<
+          ((uword & 0x0200) ? "SerialOflow " : "") <<
+          ((uword & 0x0400) ? "SerialCRC " : "") <<
+          ((uword & 0x0800) ? "SerialProto " : "") <<
+          ((uword & 0x1000) ? "TimeoutRX " : "") <<
+          ((uword == 0) ? "None" : "") << std::endl;
         break;
       default:
         std::cerr << "unexpected command " << (int)expcmd << std::endl;

--- a/poller.h
+++ b/poller.h
@@ -3,7 +3,6 @@
 
 #include <queue>
 #include <mutex>
-#include <atomic>
 #include <ostream>
 
 namespace PololuJrkUSB {
@@ -27,14 +26,16 @@ public:
   void ReadJRKErrors();
   void SetJRKTarget(int target);
   void SetJRKOff();
-  void StopPolling();
   static std::ostream& HexOutput(std::ostream& s, const void* data, size_t len);
+
+  // Direct the Poller to cease operating, but don't block on its actual exit
+  void StopPolling();
 
 private:
   int devfd;
-  std::atomic<bool> cancelled;
+  int cancelfd; // eventfd used for cancellation signal
   std::queue<unsigned char> sent_cmds;
-  std::mutex lock; // guards sent_cmds and devfd
+  std::mutex lock; // guards sent_cmds, devfd, cancelfd
 
   int OpenDev(const char* dev);
   void SendJRKReadCommand(int cmd);

--- a/pololu.cpp
+++ b/pololu.cpp
@@ -14,6 +14,8 @@
 #include <readline/readline.h>
 #include "poller.h"
 
+using namespace std::literals::string_literals;
+
 static void
 usage(std::ostream& os, int ret) {
   os << "usage: pololu dev\n";
@@ -275,7 +277,7 @@ JrkGetSerialNumber(libusb_device_handle* dev, const libusb_device_descriptor* de
     auto ret = libusb_get_string_descriptor_ascii(dev, desc->iSerialNumber,
                   serialbuf.data(), serialbuf.size());
     if(ret <= 0){
-      throw std::runtime_error(std::string("error extracting serialno: ") +
+      throw std::runtime_error("error extracting serialno: "s +
                              libusb_strerror(static_cast<libusb_error>(ret)));
     }
     std::cout << " Serial number: " << serialbuf.data() << std::endl;
@@ -290,7 +292,7 @@ JrkGetFirmwareVersion(libusb_device_handle* dev) {
   auto ret = libusb_control_transfer(dev, BMREQ_STANDARD, 6, 0x0100, 0,
                                      buffer.data(), buffer.size(), 0);
   if(ret != buffer.size()){
-    throw std::runtime_error(std::string("error extracting firmware: ") +
+    throw std::runtime_error("error extracting firmware: "s +
                              libusb_strerror(static_cast<libusb_error>(ret)));
   }
   auto minor = buffer[FIRMWARE_OFFSET] & 0xf;
@@ -306,7 +308,7 @@ LibusbGetTopology(libusb_device* dev) {
   int bus = libusb_get_bus_number(dev);
   auto ret = libusb_get_port_numbers(dev, numbers.data(), numbers.size());
   if(ret <= 0){
-    throw std::runtime_error(std::string("error locating usb device: ") +
+    throw std::runtime_error("error locating usb device: "s +
                              libusb_strerror(static_cast<libusb_error>(ret)));
   }
   std::cout << "USB device at " << bus << "-";
@@ -415,7 +417,7 @@ LibusbGetConfig(std::ostream& s, libusb_device_handle* dev) {
     int ret = libusb_control_transfer(dev, BMREQ_VENDOR, JRKUSB_GET_PARAMETER, 0,
                         static_cast<uint8_t>(param.id), data, param.bytes, 0);
     if(ret <= 0){
-      throw std::runtime_error(std::string("error reading from usb device: ") +
+      throw std::runtime_error("error reading from usb device: "s +
                                libusb_strerror(static_cast<libusb_error>(ret)));
     }
     s << " " << param.name << ": 0x";
@@ -443,7 +445,7 @@ libusb_callback(libusb_context *ctx, libusb_device *dev,
     struct libusb_device_descriptor desc;
     auto ret = libusb_get_device_descriptor(dev, &desc);
     if(ret){
-      throw std::runtime_error(std::string("error describing usb device: ") +
+      throw std::runtime_error("error describing usb device: "s +
                                libusb_strerror(static_cast<libusb_error>(ret)));
     }
     if(desc.idVendor != PololuJrkUSB::PololuVendorID){
@@ -454,7 +456,7 @@ libusb_callback(libusb_context *ctx, libusb_device *dev,
     }else{
       libusb_device_handle* handle;
       if( (ret = libusb_open(dev, &handle)) ){
-        throw std::runtime_error(std::string("error opening usb device: ") +
+        throw std::runtime_error("error opening usb device: "s +
                                 libusb_strerror(static_cast<libusb_error>(ret)));
       }
       LibusbGetTopology(dev);
@@ -492,7 +494,7 @@ int main(int argc, const char** argv) {
                                    LIBUSB_HOTPLUG_MATCH_ANY, // class
                                    libusb_callback, nullptr, &cbhandle);
   if(ret){
-    throw std::runtime_error(std::string("registering libusb callback: ") +
+    throw std::runtime_error("registering libusb callback: "s +
                              libusb_strerror(static_cast<libusb_error>(ret)));
   }
 


### PR DESCRIPTION
* Replace all instances of std::string() conversion with s suffix
* Eliminate class private atomic `cancelled`
* Add class private eventfd, poll() on it, kill off poll() tick (#14)
* Add spaces between decoded error bits